### PR TITLE
Set SDL_INIT_JOYSTICK with SDL2

### DIFF
--- a/src/sdleventreader.cpp
+++ b/src/sdleventreader.cpp
@@ -56,7 +56,9 @@ SDLEventReader::~SDLEventReader()
 void SDLEventReader::initSDL()
 {
 #ifdef USE_SDL_2
-    SDL_Init(SDL_INIT_GAMECONTROLLER);
+    // SDL_INIT_GAMECONTROLLER should automatically initialize SDL_INIT_JOYSTICK
+    // but it doesn't seem to be the case with v2.0.4
+    SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK);
 #else
     // Video support is required to use event system in SDL 1.2.
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK);


### PR DESCRIPTION
Should fix Ryochan7/antimicro-packaging#2
Can't really test it since I don't have a Windows machine.