### PR TITLE
README.md: corrected build instructions for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ support)
 In order to build this program, open a terminal and cd into the antimicro
 directory. Enter the following commands in order to build the program:
 
-    cd antimicro
+    cd antimicro*
     mkdir build && cd build
     cmake ..
     make


### PR DESCRIPTION
See https://forums.bunsenlabs.org/viewtopic.php?pid=60148#p60148 

The source tarball unpacks a numbered directory so the `cd` will fail unless the asterisk is added.

