### PR TITLE
fix compilation with clang

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -366,7 +366,7 @@ void MainWindow::makeJoystickTabs()
         ui->tabWidget->addTab(tabwidget, joytabName);
     }
 
-    if (joysticks > 0)
+    if (joysticks != nullptr)
     {
         ui->tabWidget->setCurrentIndex(0);
         ui->stackedWidget->setCurrentIndex(1);


### PR DESCRIPTION
This patch addresses a compilation problem where a
pointer is compared with greater than sign ?
clang doesn't like that and throws an error, while gcc
silently shallows this.

I figured this doesn't make any sense and that
perhaps you mean to check if the pointer is not `nullptr`?

```cpp
error: ordered comparison between pointer and zero ('QMap<SDL_JoystickID, InputDevice *> *'
      (aka 'QMap<int, InputDevice *> *') and 'int')
    if (joysticks > 0)
        ~~~~~~~~~ ^ ~
1 error generated.
```

After some testing I didn't noticed any changes in
the behavior of the application and it continues working
as before, just like when compiled with gcc.